### PR TITLE
fix non-nullary method overrides nullary method

### DIFF
--- a/codegen/src/main/twirl/templates/ScalaClient/Client.scala.txt
+++ b/codegen/src/main/twirl/templates/ScalaClient/Client.scala.txt
@@ -91,7 +91,7 @@ final class Default@{service.name}Client(settings: GrpcClientSettings)(implicit 
   }
 
   override def close(): scala.concurrent.Future[akka.Done] = clientState.close()
-  override def closed(): scala.concurrent.Future[akka.Done] = clientState.closed()
+  override def closed: scala.concurrent.Future[akka.Done] = clientState.closed()
 
 }
 


### PR DESCRIPTION
```scala
trait AkkaGrpcClient {
  ...
  def closed: scala.concurrent.Future[akka.Done]
}
```

```
[warn] non-nullary method overrides nullary method
[warn]   override def closed(): scala.concurrent.Future[akka.Done] = clientState.closed()
```